### PR TITLE
Add macOS installation to readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,15 @@ If you do not have pip installed, open osgeo4w-setup-x86_64.exe, select Advanced
 
 You can now use **Random Forest**, **SVM**, or **KNN** !
 
+### On macOS
+Open [Plugins ‣ Python Console](https://docs.qgis.org/2.18/en/docs/user_manual/plugins/python_console.html), then:
+
+`from pip._internal import main as pip`
+
+`pip(['install', '--user', 'scikit-learn'])`
+
+Restart QGIS.
+
 ## Tips
 
 - If your raster is *spot6scene.tif*, you can create your mask under the name *spot6scene_mask.tif* and the script will detect it automatically.


### PR DESCRIPTION
Successfully tested with macOS 10.13.6 (High Sierra) and 10.15.5 (Catalina), QGIS 3.10.
Solution from this comment: https://github.com/nkarasiak/dzetsaka/issues/15#issuecomment-477494992.
Not sure if restart is actually required.
In macOS High Sierra, QGIS was not responidng during the classifiation but still succeeded.