### PR TITLE
Added new environment initialisation command to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,14 @@ On **Linux** simply open terminal and type :
 `python3 -m pip install scikit-learn -U --user`
 
 ### On Windows
+**For QGIS 3.20 and higher** 
+Open OsGeo shell, then :
 
-**For Qgis 3**: 
+`o4w_env`
+
+`python3 -m pip install scikit-learn -U --user`
+
+**For Qgis 3.18 and lower**: 
 Open OsGeo shell, then :
 
 `py3_env.bat`

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ On **Linux** simply open terminal and type :
 `python3 -m pip install scikit-learn -U --user`
 
 ### On Windows
-**For QGIS 3.20 and higher** 
+**For QGIS 3.20 and higher:** 
 Open OsGeo shell, then :
 
 `o4w_env`


### PR DESCRIPTION
After QGIS 3.18, there appears to no longer be a `py3_env.bat` in the directory. Instead, the command `o4w_env` can be used to initialise the correct environment.
